### PR TITLE
Merge download_url and upload_url into a unique url property

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,19 +58,19 @@ The configuration file for the _MvnFeed CLI_ is stored in the file `~/.mvnfeed/m
     ```bash
     mvnfeed config repo list
     central
-      feed url: https://repo.maven.apache.org/maven2
+      url : http://central.maven.org/maven2
     jcenter
-      feed url: http://jcenter.bintray.com
+      url : http://jcenter.bintray.com
     jboss
-      feed url: https://repository.jboss.org/nexus/content/repositories/releases
+      url : https://repository.jboss.org/nexus/content/repositories/releases
     clojars
-      feed url: https://repo.clojars.org
+      url : https://repo.clojars.org
     atlassian
-      feed url: https://packages.atlassian.com/maven/public
+      url : https://packages.atlassian.com/maven/public
     google
-      feed url: https://maven.google.com
+      url : https://maven.google.com
     my_devops_feed
-      feed url: https://{organization}.pkgs.visualstudio.com/_packaging{feed}/maven/v1
+      url : https://{organization}.pkgs.visualstudio.com/_packaging{feed}/maven/v1
     ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -58,20 +58,19 @@ The configuration file for the _MvnFeed CLI_ is stored in the file `~/.mvnfeed/m
     ```bash
     mvnfeed config repo list
     central
-      download url: https://repo.maven.apache.org/maven2/
+      feed url: https://repo.maven.apache.org/maven2
     jcenter
-      download url: http://jcenter.bintray.com
+      feed url: http://jcenter.bintray.com
     jboss
-      download url: https://repository.jboss.org/nexus/content/repositories/releases/
+      feed url: https://repository.jboss.org/nexus/content/repositories/releases
     clojars
-      download url: https://repo.clojars.org/
+      feed url: https://repo.clojars.org
     atlassian
-      download url: https://packages.atlassian.com/maven/public
+      feed url: https://packages.atlassian.com/maven/public
     google
-      download url: https://maven.google.com/
+      feed url: https://maven.google.com
     my_devops_feed
-      download url: https://{organization}.pkgs.visualstudio.com/_packaging/{feed}/maven/v1
-      upload url  : https://{organization}.pkgs.visualstudio.com/_packaging/{feed}/maven/v1
+      feed url: https://{organization}.pkgs.visualstudio.com/_packaging{feed}/maven/v1
     ```
 
 ## Usage

--- a/src/mvnfeed_modules/mvnfeed-cli-common/mvnfeed/cli/common/config.py
+++ b/src/mvnfeed_modules/mvnfeed-cli-common/mvnfeed/cli/common/config.py
@@ -10,8 +10,7 @@ CLI_ENV_VARIABLE_PREFIX = 'MVNFEED_'
 CONFIG_FILENAME = 'mvnfeed.ini'
 
 REPOSITORY = 'repository.'
-DOWNLOAD_URL = 'download_url'
-UPLOAD_URL = 'upload_url'
+FEED_URL = 'feed_url'
 AUTHORIZATION = 'authorization'
 
 def _get_config_dir():
@@ -36,22 +35,22 @@ def load_config():
     config = configparser.ConfigParser()
 
     config[repo_section_name('central')] = {
-        DOWNLOAD_URL: 'https://repo.maven.apache.org/maven2/'
+        FEED_URL: 'https://repo.maven.apache.org/maven2'
     }
     config[repo_section_name('jcenter')] = {
-        DOWNLOAD_URL: 'http://jcenter.bintray.com'
+        FEED_URL: 'http://jcenter.bintray.com'
     }
     config[repo_section_name('jboss')] = {
-        DOWNLOAD_URL: 'https://repository.jboss.org/nexus/content/repositories/releases/'
+        FEED_URL: 'https://repository.jboss.org/nexus/content/repositories/releases'
     }
     config[repo_section_name('clojars')] = {
-        DOWNLOAD_URL: 'https://repo.clojars.org/'
+        FEED_URL: 'https://repo.clojars.org'
     }
     config[repo_section_name('atlassian')] = {
-        DOWNLOAD_URL: 'https://packages.atlassian.com/maven/public'
+        FEED_URL: 'https://packages.atlassian.com/maven/public'
     }
     config[repo_section_name('google')] = {
-        DOWNLOAD_URL: 'https://maven.google.com/'
+        FEED_URL: 'https://maven.google.com'
     }
 
     save_config(config, filename)

--- a/src/mvnfeed_modules/mvnfeed-cli-common/mvnfeed/cli/common/config.py
+++ b/src/mvnfeed_modules/mvnfeed-cli-common/mvnfeed/cli/common/config.py
@@ -10,7 +10,7 @@ CLI_ENV_VARIABLE_PREFIX = 'MVNFEED_'
 CONFIG_FILENAME = 'mvnfeed.ini'
 
 REPOSITORY = 'repository.'
-FEED_URL = 'feed_url'
+URL = 'url'
 AUTHORIZATION = 'authorization'
 
 def _get_config_dir():
@@ -35,22 +35,22 @@ def load_config():
     config = configparser.ConfigParser()
 
     config[repo_section_name('central')] = {
-        FEED_URL: 'https://repo.maven.apache.org/maven2'
+        URL: 'https://repo.maven.apache.org/maven2'
     }
     config[repo_section_name('jcenter')] = {
-        FEED_URL: 'http://jcenter.bintray.com'
+        URL: 'http://jcenter.bintray.com'
     }
     config[repo_section_name('jboss')] = {
-        FEED_URL: 'https://repository.jboss.org/nexus/content/repositories/releases'
+        URL: 'https://repository.jboss.org/nexus/content/repositories/releases'
     }
     config[repo_section_name('clojars')] = {
-        FEED_URL: 'https://repo.clojars.org'
+        URL: 'https://repo.clojars.org'
     }
     config[repo_section_name('atlassian')] = {
-        FEED_URL: 'https://packages.atlassian.com/maven/public'
+        URL: 'https://packages.atlassian.com/maven/public'
     }
     config[repo_section_name('google')] = {
-        FEED_URL: 'https://maven.google.com'
+        URL: 'https://maven.google.com'
     }
 
     save_config(config, filename)

--- a/src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/arguments.py
+++ b/src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/arguments.py
@@ -12,7 +12,7 @@ def load_transfer_arguments(cli_command_loader):
     with knack.arguments.ArgumentsContext(cli_command_loader, 'config repo add') as ac:
         ac.argument('name', options_list=('--name'))
         ac.argument('username', options_list=('--username'))
-        ac.argument('feed_url', options_list=('--feed_url'))
+        ac.argument('url', options_list=('--url'))
 
     with knack.arguments.ArgumentsContext(cli_command_loader, 'config repo delete') as ac:
         ac.argument('name', options_list=('--name'))

--- a/src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/arguments.py
+++ b/src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/arguments.py
@@ -12,8 +12,7 @@ def load_transfer_arguments(cli_command_loader):
     with knack.arguments.ArgumentsContext(cli_command_loader, 'config repo add') as ac:
         ac.argument('name', options_list=('--name'))
         ac.argument('username', options_list=('--username'))
-        ac.argument('download_url', options_list=('--download_url'))
-        ac.argument('upload_url', options_list=('--upload_url'))
+        ac.argument('feed_url', options_list=('--feed_url'))
 
     with knack.arguments.ArgumentsContext(cli_command_loader, 'config repo delete') as ac:
         ac.argument('name', options_list=('--name'))

--- a/src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/configuration.py
+++ b/src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/configuration.py
@@ -6,7 +6,7 @@
 import base64
 import getpass
 
-from mvnfeed.cli.common.config import REPOSITORY, AUTHORIZATION, FEED_URL, FEED_URL, repo_section_name, load_config, save_config
+from mvnfeed.cli.common.config import REPOSITORY, AUTHORIZATION, URL, URL, repo_section_name, load_config, save_config
 
 STAGE_DIR_CONFIGNAME = 'stage_dir'
 
@@ -35,13 +35,13 @@ def view_stagedir():
     return config.get('general', STAGE_DIR_CONFIGNAME)
 
 
-def add_repository(name, username, feed_url=None):
+def add_repository(name, username, url=None):
     """
     Adds an external Maven repository.
 
     :param name: internal name of the repository
     :param username: name of the user for the basic authentication to the repository
-    :param feed_url: url of the Maven feed
+    :param url: url of the repository
     """
     if username is None:
         raise ValueError('Username must be defined')
@@ -54,7 +54,7 @@ def add_repository(name, username, feed_url=None):
 
     config = load_config()
     config[repo_section_name(name)] = {
-        FEED_URL: _default_value(feed_url),
+        URL: _default_value(url),
         AUTHORIZATION: _default_value(authorization)
     }
     save_config(config)
@@ -80,8 +80,8 @@ def list_repositories():
         if section.startswith(REPOSITORY):
             repo = config[section]
             print(section[11:])
-            if FEED_URL in repo:
-                print('  feed url  : ' + repo[FEED_URL])
+            if URL in repo:
+                print('  url : ' + repo[URL])
 
 
 def get_repository(config, name):

--- a/src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/configuration.py
+++ b/src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/configuration.py
@@ -5,7 +5,8 @@
 
 import base64
 import getpass
-from mvnfeed.cli.common.config import REPOSITORY, AUTHORIZATION, DOWNLOAD_URL, UPLOAD_URL, repo_section_name, load_config, save_config
+
+from mvnfeed.cli.common.config import REPOSITORY, AUTHORIZATION, FEED_URL, FEED_URL, repo_section_name, load_config, save_config
 
 STAGE_DIR_CONFIGNAME = 'stage_dir'
 
@@ -34,14 +35,13 @@ def view_stagedir():
     return config.get('general', STAGE_DIR_CONFIGNAME)
 
 
-def add_repository(name, username, upload_url=None, download_url=None):
+def add_repository(name, username, feed_url=None):
     """
     Adds an external Maven repository.
 
     :param name: internal name of the repository
     :param username: name of the user for the basic authentication to the repository
-    :param upload_url: url for uploading the mvnfeed
-    :param download_url: url for downloading the mvnfeed
+    :param feed_url: url of the Maven feed
     """
     if username is None:
         raise ValueError('Username must be defined')
@@ -54,8 +54,7 @@ def add_repository(name, username, upload_url=None, download_url=None):
 
     config = load_config()
     config[repo_section_name(name)] = {
-        DOWNLOAD_URL: _default_value(download_url),
-        UPLOAD_URL: _default_value(upload_url),
+        FEED_URL: _default_value(feed_url),
         AUTHORIZATION: _default_value(authorization)
     }
     save_config(config)
@@ -81,10 +80,8 @@ def list_repositories():
         if section.startswith(REPOSITORY):
             repo = config[section]
             print(section[11:])
-            if UPLOAD_URL in repo:
-                print('  upload url  : ' + repo[UPLOAD_URL])
-            if DOWNLOAD_URL in repo and repo[DOWNLOAD_URL]:
-                print('  download url: ' + repo[DOWNLOAD_URL])
+            if FEED_URL in repo:
+                print('  feed url  : ' + repo[FEED_URL])
 
 
 def get_repository(config, name):

--- a/src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/transfer.py
+++ b/src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/transfer.py
@@ -15,7 +15,7 @@ except ImportError:
     # Python 2
     from urllib2 import Request, urlopen
 from .configuration import get_repository, get_stagedir, get_repository_shortname
-from mvnfeed.cli.common.config import AUTHORIZATION, DOWNLOAD_URL, UPLOAD_URL, load_config
+from mvnfeed.cli.common.config import AUTHORIZATION, FEED_URL, load_config
 
 
 def transfer_artifact(name, from_repo, to_repo, transfer_deps=False):
@@ -62,8 +62,8 @@ def transfer_bulk(filename, from_repo, to_repo, transfer_deps=False):
 
 
 def _transfer_single_artifact(name, from_repository, to_repository, stage_dir, transfer_deps):
-    logging.debug('download url: %s', from_repository[DOWNLOAD_URL])
-    logging.debug('upload url: %s', to_repository[UPLOAD_URL])
+    logging.debug('download url: %s', from_repository[FEED_URL])
+    logging.debug('upload url: %s', to_repository[FEED_URL])
     logging.debug('stage directory: %s', stage_dir)
 
     if not os.path.exists(stage_dir):
@@ -244,10 +244,10 @@ def _download_file(from_repository, path, filename, length=16*1024):
     if os.path.exists(filename):
         logging.debug('%s already downloaded', filename)
 
-    if not DOWNLOAD_URL in from_repository or not from_repository[DOWNLOAD_URL]:
-        raise ValueError('Repository missing download url: ' + get_repository_shortname(from_repository))
+    if not FEED_URL in from_repository or not from_repository[FEED_URL]:
+        raise ValueError('Repository missing feed url: ' + get_repository_shortname(from_repository))
 
-    url = from_repository[DOWNLOAD_URL] + '/' + path
+    url = from_repository[FEED_URL] + '/' + path
     logging.debug('downloading from %s', url)
     try:
         request = Request(url)
@@ -269,9 +269,9 @@ def _already_uploaded(to_repository, path):
     """
     Return True if the file was already uploaded.
     """
-    if not UPLOAD_URL in to_repository or not to_repository[UPLOAD_URL]:
-        raise ValueError('Repository missing upload url: ' + get_repository_shortname(to_repository))
-    url = to_repository[UPLOAD_URL] + '/' + path
+    if not FEED_URL in to_repository or not to_repository[FEED_URL]:
+        raise ValueError('Repository missing feed url: ' + get_repository_shortname(to_repository))
+    url = to_repository[FEED_URL] + '/' + path
 
     if AUTHORIZATION in to_repository and to_repository[AUTHORIZATION]:
         logging.debug('authorization header added')
@@ -298,9 +298,9 @@ def _upload_file(to_repository, path, filename):
         logging.debug('missing file to upload, skipping %s', filename)
         return False
 
-    if not UPLOAD_URL in to_repository or not to_repository[UPLOAD_URL]:
-        raise ValueError('Repository missing upload url: ' + get_repository_shortname(to_repository))
-    url = to_repository[UPLOAD_URL] + '/' + path
+    if not FEED_URL in to_repository or not to_repository[FEED_URL]:
+        raise ValueError('Repository missing feed url: ' + get_repository_shortname(to_repository))
+    url = to_repository[FEED_URL] + '/' + path
 
     logging.debug('uploading to ' + url)
     if AUTHORIZATION in to_repository and to_repository[AUTHORIZATION]:

--- a/src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/transfer.py
+++ b/src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/transfer.py
@@ -15,7 +15,7 @@ except ImportError:
     # Python 2
     from urllib2 import Request, urlopen
 from .configuration import get_repository, get_stagedir, get_repository_shortname
-from mvnfeed.cli.common.config import AUTHORIZATION, FEED_URL, load_config
+from mvnfeed.cli.common.config import AUTHORIZATION, URL, load_config
 
 
 def transfer_artifact(name, from_repo, to_repo, transfer_deps=False):
@@ -62,8 +62,8 @@ def transfer_bulk(filename, from_repo, to_repo, transfer_deps=False):
 
 
 def _transfer_single_artifact(name, from_repository, to_repository, stage_dir, transfer_deps):
-    logging.debug('download url: %s', from_repository[FEED_URL])
-    logging.debug('upload url: %s', to_repository[FEED_URL])
+    logging.debug('download url: %s', from_repository[URL])
+    logging.debug('upload url: %s', to_repository[URL])
     logging.debug('stage directory: %s', stage_dir)
 
     if not os.path.exists(stage_dir):
@@ -244,10 +244,10 @@ def _download_file(from_repository, path, filename, length=16*1024):
     if os.path.exists(filename):
         logging.debug('%s already downloaded', filename)
 
-    if not FEED_URL in from_repository or not from_repository[FEED_URL]:
-        raise ValueError('Repository missing feed url: ' + get_repository_shortname(from_repository))
+    if not URL in from_repository or not from_repository[URL]:
+        raise ValueError('Repository missing url: ' + get_repository_shortname(from_repository))
 
-    url = from_repository[FEED_URL] + '/' + path
+    url = from_repository[URL] + '/' + path
     logging.debug('downloading from %s', url)
     try:
         request = Request(url)
@@ -269,9 +269,9 @@ def _already_uploaded(to_repository, path):
     """
     Return True if the file was already uploaded.
     """
-    if not FEED_URL in to_repository or not to_repository[FEED_URL]:
-        raise ValueError('Repository missing feed url: ' + get_repository_shortname(to_repository))
-    url = to_repository[FEED_URL] + '/' + path
+    if not URL in to_repository or not to_repository[URL]:
+        raise ValueError('Repository missing url: ' + get_repository_shortname(to_repository))
+    url = to_repository[URL] + '/' + path
 
     if AUTHORIZATION in to_repository and to_repository[AUTHORIZATION]:
         logging.debug('authorization header added')
@@ -298,9 +298,9 @@ def _upload_file(to_repository, path, filename):
         logging.debug('missing file to upload, skipping %s', filename)
         return False
 
-    if not FEED_URL in to_repository or not to_repository[FEED_URL]:
-        raise ValueError('Repository missing feed url: ' + get_repository_shortname(to_repository))
-    url = to_repository[FEED_URL] + '/' + path
+    if not URL in to_repository or not to_repository[URL]:
+        raise ValueError('Repository missing url: ' + get_repository_shortname(to_repository))
+    url = to_repository[URL] + '/' + path
 
     logging.debug('uploading to ' + url)
     if AUTHORIZATION in to_repository and to_repository[AUTHORIZATION]:


### PR DESCRIPTION
Merge the `download_url` and `upload_url` into a single `url` property.
To download and upload from the same repository, simply create two distinct repositories.