### PR TITLE
Declare as global undefined variables 'upload_url' and 'download_url'

### DIFF
--- a/src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/configuration.py
+++ b/src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/configuration.py
@@ -43,6 +43,7 @@ def add_repository(name, username, url=None):
     :param username: name of the user for the basic authentication to the repository
     :param url: url of the repository
     """
+    global upload_url, download_url
     if username is None:
         raise ValueError('Username must be defined')
     if upload_url is None and download_url is None:


### PR DESCRIPTION
__upload_url__ and __download_url__ are _undefined names_ in this context that have the potential to raise NameError at runtime. 

[flake8](http://flake8.pycqa.org) testing of https://github.com/microsoft/mvnfeed-cli on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/configuration.py:48:8: F821 undefined name 'upload_url'
    if upload_url is None and download_url is None:
       ^
./src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/configuration.py:48:31: F821 undefined name 'download_url'
    if upload_url is None and download_url is None:
                              ^
2     F821 undefined name 'upload_url'
2
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree