### PR TITLE
Gitlab http Authentication header support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM --platform=arm64 python:3-bookworm
+
+RUN mkdir /opt/app 
+WORKDIR /opt/app
+
+# Have to use older pyyaml than the container provides
+# https://github.com/yaml/pyyaml/issues/601#issuecomment-1693730229
+# it's even more fun, because python dependencies are a nightmare.
+RUN pip install "Cython<3.0" pyyaml==5.4.1 --no-build-isolation
+
+COPY . /opt/app
+RUN python3 scripts/dev_setup.py \
+  && mvnfeed -h
+
+# configuration file is at ~/.mvnfeed/mvnfeed.ini
+
+ENTRYPOINT ["/usr/local/bin/mvnfeed"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=arm64 python:3-bookworm
+FROM python:3-bookworm
 
 RUN mkdir /opt/app 
 WORKDIR /opt/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,14 @@ WORKDIR /opt/app
 # Have to use older pyyaml than the container provides
 # https://github.com/yaml/pyyaml/issues/601#issuecomment-1693730229
 # it's even more fun, because python dependencies are a nightmare.
-RUN pip install "Cython<3.0" pyyaml==5.4.1 --no-build-isolation
+RUN pip install "Cython<3.0" pyyaml==5.4.1 --no-build-isolation \
+    && pip install requests
 
 COPY . /opt/app
 RUN python3 scripts/dev_setup.py \
+  && mkdir /srv/mvnfeed_stage \
   && mvnfeed -h
+
 
 # configuration file is at ~/.mvnfeed/mvnfeed.ini
 

--- a/src/mvnfeed_modules/mvnfeed-cli-common/mvnfeed/cli/common/config.py
+++ b/src/mvnfeed_modules/mvnfeed-cli-common/mvnfeed/cli/common/config.py
@@ -12,6 +12,8 @@ CONFIG_FILENAME = 'mvnfeed.ini'
 REPOSITORY = 'repository.'
 URL = 'url'
 AUTHORIZATION = 'authorization'
+AUTH_HEADER = 'auth_header'
+AUTH_VALUE = 'auth_value'
 
 
 def _get_config_dir():

--- a/src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/configuration.py
+++ b/src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/configuration.py
@@ -6,7 +6,7 @@
 import base64
 import getpass
 
-from mvnfeed.cli.common.config import REPOSITORY, AUTHORIZATION, URL, repo_section_name, load_config, save_config
+from mvnfeed.cli.common.config import REPOSITORY, AUTHORIZATION, URL, AUTH_HEADER, AUTH_VALUE, repo_section_name, load_config, save_config
 
 STAGE_DIR_CONFIGNAME = 'stage_dir'
 
@@ -36,27 +36,32 @@ def view_stagedir():
     return config.get('general', STAGE_DIR_CONFIGNAME)
 
 
-def add_repository(name, username, url=None):
+def add_repository(name, username=None, url=None, auth_header=None, auth_value=None):
     """
     Adds an external Maven repository.
 
     :param name: internal name of the repository
     :param username: name of the user for the basic authentication to the repository
     :param url: url of the repository
+    :param auth_header: name of an auth header
+    :param auth_value: value in that auth header
     """
-    if username is None:
-        raise ValueError('Username must be defined')
     if url is None:
         raise ValueError('Url must be defined')
 
-    password = getpass.getpass()
-    encoded = base64.b64encode((username + ':' + password).encode('utf-8'))
-    authorization = 'Basic ' + encoded.decode('utf-8')
+    if username is not None:
+        password = getpass.getpass()
+        encoded = base64.b64encode((username + ':' + password).encode('utf-8'))
+        authorization = 'Basic ' + encoded.decode('utf-8')
+    else:
+        authorization = None
 
     config = load_config()
     config[repo_section_name(name)] = {
         URL: _default_value(url),
-        AUTHORIZATION: _default_value(authorization)
+        AUTHORIZATION: _default_value(authorization),
+        AUTH_HEADER: _default_value(auth_header),
+        AUTH_VALUE: _default_value(auth_value)
     }
     save_config(config)
 

--- a/src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/transfer.py
+++ b/src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/transfer.py
@@ -15,7 +15,7 @@ except ImportError:
     # Python 2
     from urllib2 import Request, urlopen
 from .configuration import get_repository, get_stagedir, get_repository_shortname
-from mvnfeed.cli.common.config import AUTHORIZATION, URL, load_config
+from mvnfeed.cli.common.config import AUTHORIZATION, URL, AUTH_HEADER, AUTH_VALUE, load_config
 
 
 def transfer_artifact(name, from_repo, to_repo, transfer_deps=False):
@@ -261,6 +261,9 @@ def _download_file(from_repository, path, filename, length=16*1024):
         if AUTHORIZATION in from_repository and from_repository[AUTHORIZATION]:
             logging.debug('authorization header added')
             request.add_header('Authorization', from_repository[AUTHORIZATION])
+        elif AUTH_HEADER in from_repository and from_repository[AUTH_HEADER]:
+            logging.debug('custom auth header added')
+            request.add_header(from_repository[AUTH_HEADER], from_repository[AUTH_VALUE])
         else:
             logging.debug('no authorization configured')
 
@@ -283,6 +286,9 @@ def _already_uploaded(to_repository, path):
     if AUTHORIZATION in to_repository and to_repository[AUTHORIZATION]:
         logging.debug('authorization header added')
         headers = {'Authorization': to_repository[AUTHORIZATION]}
+    elif AUTH_HEADER in to_repository and to_repository[AUTH_HEADER]:
+        logging.debug('custom auth header added')
+        headers = {to_repository[AUTH_HEADER]: to_repository[AUTH_VALUE]}
     else:
         logging.debug('no authorization configured')
         headers = {}
@@ -313,10 +319,12 @@ def _upload_file(to_repository, path, filename):
     if AUTHORIZATION in to_repository and to_repository[AUTHORIZATION]:
         logging.debug('authorization header added')
         headers = {'Authorization': to_repository[AUTHORIZATION]}
+    elif AUTH_HEADER in to_repository and to_repository[AUTH_HEADER]:
+        logging.debug('custom auth header added')
+        headers = {to_repository[AUTH_HEADER]: to_repository[AUTH_VALUE]}
     else:
         logging.debug('no authorization configured')
         headers = {}
-
     try:
         with open(filename, 'rb') as file:
             response = requests.put(url, files={filename: file}, headers=headers)


### PR DESCRIPTION
in order to push artifacts into a gitlab maven package repo, I had to add authentication header support. Gitlab doesn't support basic auth. 

That worked out fine, but I also had a great deal of trouble running it locally, so I ended up building a container to run it in, included that Dockerfile as well, relating to #13 