### PR TITLE
Upload shasum files and cut content disposition writing for all files

### DIFF
--- a/src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/transfer.py
+++ b/src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/transfer.py
@@ -223,6 +223,11 @@ def _java_artifacts(artifact_fullname, artifact_type, artifact_path, transfer_de
             'target': False
         },
         {
+            'name': artifact_fullname + '-sources.jar.sha1',
+            'path': artifact_path,
+            'target': False
+        },
+        {
             'name': artifact_fullname + '-javadoc.jar',
             'path': artifact_path,
             'target': False

--- a/src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/transfer.py
+++ b/src/mvnfeed_modules/mvnfeed-cli-transfer/mvnfeed/cli/transfer/transfer.py
@@ -197,9 +197,19 @@ def _java_artifacts(artifact_fullname, artifact_type, artifact_path, transfer_de
             'target': True
         },
         {
+            'name': artifact_fullname + '.jar.sha1',
+            'path': artifact_path,
+            'target': False
+        },
+        {
             'name': artifact_fullname + '.pom',
             'path': artifact_path,
             'transfer_deps': transfer_deps,
+            'target': False
+        },
+        {
+            'name': artifact_fullname + '.pom.sha1',
+            'path': artifact_path,
             'target': False
         },
         {
@@ -232,6 +242,11 @@ def _untyped_artifacts(artifact_fullname, artifact_type, artifact_path, transfer
             'name': artifact_fullname + '.pom',
             'path': artifact_path,
             'transfer_deps': transfer_deps,
+            'target': False
+        },
+        {
+            'name': artifact_fullname + '.pom.sha1',
+            'path': artifact_path,
             'target': False
         }
     ]
@@ -319,7 +334,7 @@ def _upload_file(to_repository, path, filename):
 
     try:
         with open(filename, 'rb') as file:
-            response = requests.put(url, files={filename: file}, headers=headers)
+            response = requests.put(url, data=file.read(), headers=headers)
             if not response.ok:
                 logging.error('error while uploading of %s: %s', path, response.text)
         return True


### PR DESCRIPTION
1. Checksum files are not being uploaded
2. the python code is writing `content-disposition` information into the uploaded files.
3. 
I thought about adding md5 checksum files too - but decided against this as it would slow the process down.